### PR TITLE
Solve buffer and cursor position issues

### DIFF
--- a/autoload/vim_addon_qf_layout.vim
+++ b/autoload/vim_addon_qf_layout.vim
@@ -10,35 +10,15 @@ fun! vim_addon_qf_layout#Quickfix()
     setlocal colorcolumn=
     setlocal nowrap
     setlocal nolist
-    setlocal modifiable
 
-    let list = getqflist()
 
-    if empty(list) | return
-    end
+    if empty(getqflist()) | return | endif
 
-    " Goto the last used window---
-    wincmd W                      |
-    "                             |
-    let pos     =  getpos('.')    |
-    let pos[0]  =   bufnr('%')    |
-    "                             |
-    " Goto Quickfix window--------
-    wincmd w
-
-    exec 'noremap '. s:c.lhs_cycle .' :call vim_addon_qf_layout#Cycle()<cr>'
+    exec 'noremap <buffer> '. s:c.lhs_cycle .' :call vim_addon_qf_layout#Cycle()<cr>'
 
     let b:vim_addon_qf_layout_cycle_id = 0
     call vim_addon_qf_layout#ReformatWith(s:c.quickfix_formatters[0])
 
-    let nearest_entry = list[0]
-
-    " TODO
-    " exec 'cc' nearest_entry.number
-
-    call setpos('.', [0] + pos[1:-1])
-
-    wincmd w
   end
 
 endf
@@ -57,8 +37,11 @@ fun! vim_addon_qf_layout#ReformatWith(f)
   if &filetype != 'qf' | echoe "not in quickfix window, not formatting anything (TODO)" | return
   endif
 
+  let pos =  getpos('.')
   if a:f == 'NOP' | return | endif
   let F = a:f
+
+  setlocal modifiable
 
   " delete old contents (luckily Vim will keep knowing which line belongs to
   " what entry ..
@@ -66,8 +49,12 @@ fun! vim_addon_qf_layout#ReformatWith(f)
 
   call call(F, [])
 
+  call setpos('.', [0] + pos[1:-1])
+
+  setlocal nomodifiable
+
   " allow :q without vim yelling
-  set nomodified
+  setlocal nomodified
 endf
 
 " ===================== SAMPLE FORMATTERS

--- a/plugin/vim_addon_qf_layout.vim
+++ b/plugin/vim_addon_qf_layout.vim
@@ -1,3 +1,6 @@
+if exists("g:loaded_vim_addon_qf_layout") | finish | endif
+let g:loaded_vim_addon_qf_layout = 1
+
 if !exists('g:vim_addon_qf_layout') | let g:vim_addon_qf_layout = {} | endif | let s:c = g:vim_addon_qf_layout
 
 " order of formatters to be used when cycling


### PR DESCRIPTION
First of all, thank you for sharing this plugin! 
I've missed this functionality for quite some time.

I've found some small issues, and addressed them as follows:

* include load guard (make it easier to compare plugin side-effects)
* restore 'nomodifiable' after changing the qf format in order to avoid
  unintended changes
* remove the wincmds from the `filetype qf` autocmd:
        - they are unnecessary
        - for some reason they causes the original window to be changed to
          nomodifiable
        - restoring the original buffer on the original window causes
          unexpected effects when using cscope, e.g.: the window is displaying
          file A, `cs find s <patter>` causes qf window to open e then changes
          the window to file B. After formating the qf the plugin was changing
          the window back to file A on a unrelated line
* after cycling the qf formating the cursor was moved to the last line
* changed the mapping to buffer-local, as vim_addon_qf_layout#ReformatWith
  aborts if it is called from another buffer