### PR TITLE
Allow custom formats based on quickfix cmd

### DIFF
--- a/autoload/vim_addon_qf_layout.vim
+++ b/autoload/vim_addon_qf_layout.vim
@@ -16,8 +16,22 @@ fun! vim_addon_qf_layout#Quickfix()
 
     exec 'noremap <buffer> '. s:c.lhs_cycle .' :call vim_addon_qf_layout#Cycle()<cr>'
 
-    let b:vim_addon_qf_layout_cycle_id = 0
-    call vim_addon_qf_layout#ReformatWith(s:c.quickfix_formatters[0])
+    if !empty(g:vim_addon_qf_layout_temp_formatter)
+      call vim_addon_qf_layout#ReformatWith(g:vim_addon_qf_layout_temp_formatter)
+      " clear the filter after used to avoid issues with cnext/cold
+      let g:vim_addon_qf_layout_temp_formatter = ""
+      " g:vim_addon_qf_layout_temp_formatter can be used to set specific formats
+      " depending on the quickfix command used through QuickFixCmdPost. It is
+      " not possible to use a dict with custom formatters for each command
+      " because 1) the w:quickfix_title is set only after the relevant autocmds
+      " are executed and 2) w:quickfix_title isn't updated with cnext and cold.
+      " Maybe this can be improved after this patch is completed/accepted:
+      " https://groups.google.com/forum/#!topic/vim_dev/X7VVPd4Do5s
+      let b:vim_addon_qf_layout_cycle_id = -1
+    else
+      let b:vim_addon_qf_layout_cycle_id = 0
+      call vim_addon_qf_layout#ReformatWith(s:c.quickfix_formatters[0])
+    endif
 
   end
 

--- a/plugin/vim_addon_qf_layout.vim
+++ b/plugin/vim_addon_qf_layout.vim
@@ -15,5 +15,9 @@ let s:c.file_name_align_max_width = 60
 
 let s:c.hold_cursor = get(s:c, 'hold_cursor', 1)
 
+if !exists("g:vim_addon_qf_layout_temp_formatter")
+   let g:vim_addon_qf_layout_temp_formatter = ""
+endif
+
 " whenever the quickfix window gets opened, enhance it:
 auto filetype qf call vim_addon_qf_layout#Quickfix()


### PR DESCRIPTION
It it is possible to set the default formatter in the first element of `g:vim_addon_qf_layout.quickfix_formatters`, but it will apply for every command.
Although the formatters are very useful for search commands, they can disrupt the output of commands like `:make`.

Thus it would be useful to have custom formats depending on the command executed.