### PR TITLE
Only show basename instead of the entire file path

### DIFF
--- a/autoload/vim_addon_qf_layout.vim
+++ b/autoload/vim_addon_qf_layout.vim
@@ -81,7 +81,7 @@ fun! vim_addon_qf_layout#DefaultFormatter()
   " obsolete nowadays.
 
   for l in list
-    let l.filename = bufname(l.bufnr)
+    let l.filename = fnamemodify(bufname(l.bufnr), ":t")
   endfor
 
   let max_filename_len = max(map(copy(list), 'len(v:val.filename)' ))


### PR DESCRIPTION
This is just a suggestion, but I find it quite useful so thought I would share. Ideally, I guess it should be made a separate format option, but for now I have just replaced the default layout.