### PR TITLE
avoid E788 in isLocList()

### DIFF
--- a/autoload/vim_addon_qf_layout.vim
+++ b/autoload/vim_addon_qf_layout.vim
@@ -131,7 +131,7 @@ fun! vim_addon_qf_layout#isLocList()
   " it is necessary to check the current filename a location list may have no
   " elements (e.g.: lgrep return no matches)
   redir => l:ctrl_g
-  silent file
+  silent exe "normal! \<C-G>"
   redir END
 
   if !empty(getloclist(0)) || l:ctrl_g =~ 'Location List'


### PR DESCRIPTION
With the latest Vim versions issuing `silent file` on the location list
is returing an error:

        Error detected while processing function vim_addon_qf_layout#Quickfix[3]..vim_addon_qf_layout#GetList[1]..vim_addon_qf_layout#isLocList:
        line    4:
        E788: Not allowed to edit another buffer now

The error seems incorrect, as the command is only echoing information on
the screen. But is is easier to just replace it with the equivalent
normal command.